### PR TITLE
Fixed bug with `MPI_Init_thread` traces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ SRC=src
 PWD=$(shell pwd)
 
 build: libinterpol.so
-	@export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PWD)/interpol-rs/target/release/
+	@export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PWD)/interpol-rs/target/release/:$(PWD)
 
 install: build
-	@cp libinterpol.so /usr/lib/
+	@cp libinterpol.so interpol-rs/target/release/libinterpol_rs.so /usr/lib/
 
 uninstall:
-	@rm /usr/lib/libinterpol.so
+	@rm /usr/lib/libinterpol.so /usr/lib/libinterpol_rs.so 
 
 libinterpol.so: $(RS_LIB)/libinterpol_rs.so $(INCLUDE)/tsc.h $(SRC)/interpol.c $(INCLUDE)/interpol.h
 	$(CC) $(CFLAGS) $(OFLAGS) -I$(INCLUDE) -L$(RS_LIB) -fPIC -shared $(SRC)/interpol.c -o $@ -linterpol_rs

--- a/include/interpol.h
+++ b/include/interpol.h
@@ -30,10 +30,10 @@ void register_init(MpiRank current_rank, Tsc tsc, Usecs time);
  * Registers an `MPI_Init_thread` call into a static vector.
  */
 void register_init_thread(MpiRank current_rank,
-                          Tsc tsc,
-                          Usecs time,
                           int32_t required_thread_lvl,
-                          int32_t provided_thread_lvl);
+                          int32_t provided_thread_lvl,
+                          Tsc tsc,
+                          Usecs time);
 
 /**
  * Registers an `MPI_Finalize` call into a static vector.

--- a/interpol-rs/src/interpol.rs
+++ b/interpol-rs/src/interpol.rs
@@ -92,10 +92,10 @@ pub extern "C" fn register_init(current_rank: MpiRank, tsc: Tsc, time: Usecs) {
 #[no_mangle]
 pub extern "C" fn register_init_thread(
     current_rank: MpiRank,
-    tsc: Tsc,
-    time: Usecs,
     required_thread_lvl: i32,
     provided_thread_lvl: i32,
+    tsc: Tsc,
+    time: Usecs,
 ) {
     let init_thread_event = match MpiInitThreadBuilder::default()
         .current_rank(current_rank)


### PR DESCRIPTION
## Description
This PR fixes a bug with the traces generated when intercepting calls to `MPI_Init_thread`. The arguments in the `register_init_thread` function from `interpol-rs`'s API were in the wrong order and produced an incorrect output in the JSON trace.