### PR TITLE
Fixed compiler warning and updated  `root_rank` field to `partner_rank`

### DIFF
--- a/interpol-rs/Cargo.toml
+++ b/interpol-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpol-rs"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [build-dependencies]

--- a/interpol-rs/src/interpol.rs
+++ b/interpol-rs/src/interpol.rs
@@ -545,7 +545,7 @@ fn register_wait(
 
 fn register_ibcast(
     current_rank: MpiRank,
-    root_rank: MpiRank,
+    partner_rank: MpiRank,
     nb_bytes: u32,
     comm: MpiComm,
     req: MpiReq,
@@ -554,7 +554,7 @@ fn register_ibcast(
 ) -> Result<(), InterpolError> {
     let ibcast_event = MpiIbcastBuilder::default()
         .current_rank(current_rank)
-        .root_rank(root_rank)
+        .partner_rank(partner_rank)
         .nb_bytes(nb_bytes)
         .comm(comm)
         .req(req)
@@ -572,7 +572,7 @@ fn register_ibcast(
 
 fn register_igather(
     current_rank: MpiRank,
-    root_rank: MpiRank,
+    partner_rank: MpiRank,
     nb_bytes_send: u32,
     nb_bytes_recv: u32,
     comm: MpiComm,
@@ -582,7 +582,7 @@ fn register_igather(
 ) -> Result<(), InterpolError> {
     let igather_event = MpiIgatherBuilder::default()
         .current_rank(current_rank)
-        .root_rank(root_rank)
+        .partner_rank(partner_rank)
         .nb_bytes_send(nb_bytes_send)
         .nb_bytes_recv(nb_bytes_recv)
         .comm(comm)
@@ -601,7 +601,7 @@ fn register_igather(
 
 fn register_ireduce(
     current_rank: MpiRank,
-    root_rank: MpiRank,
+    partner_rank: MpiRank,
     nb_bytes: u32,
     op_type: i8,
     comm: MpiComm,
@@ -611,7 +611,7 @@ fn register_ireduce(
 ) -> Result<(), InterpolError> {
     let ireduce_event = MpiIreduceBuilder::default()
         .current_rank(current_rank)
-        .root_rank(root_rank)
+        .partner_rank(partner_rank)
         .nb_bytes(nb_bytes)
         .op_type(op_type)
         .comm(comm)
@@ -630,7 +630,7 @@ fn register_ireduce(
 
 fn register_iscatter(
     current_rank: MpiRank,
-    root_rank: MpiRank,
+    partner_rank: MpiRank,
     nb_bytes_send: u32,
     nb_bytes_recv: u32,
     comm: MpiComm,
@@ -640,7 +640,7 @@ fn register_iscatter(
 ) -> Result<(), InterpolError> {
     let iscatter_event = MpiIscatterBuilder::default()
         .current_rank(current_rank)
-        .root_rank(root_rank)
+        .partner_rank(partner_rank)
         .nb_bytes_send(nb_bytes_send)
         .nb_bytes_recv(nb_bytes_recv)
         .comm(comm)
@@ -667,7 +667,7 @@ pub extern "C" fn sort_all_traces() {
     let start = std::time::Instant::now();
     all_traces.par_sort_unstable_by_key(|event| event.tsc());
     let end = start.elapsed();
-    println!("Sort took {end:?}");
+    eprintln!("Sort took {end:?}");
 
     let serialized_traces =
         serde_json::to_string_pretty(&all_traces).expect("failed to serialize all traces");

--- a/interpol-rs/src/lib.rs
+++ b/interpol-rs/src/lib.rs
@@ -22,9 +22,9 @@ impl std::fmt::Display for InterpolError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let err_msg = match self.kind {
             InterpolErrorKind::Io => format!("I/O error: {}", self.reason),
-            InterpolErrorKind::TryReserve => format!("TryReserve error: {}", self.reason),
-            InterpolErrorKind::Io => format!("DeriveBuilder error: {}", self.reason),
-            _ => String::from("Unknown error kind"),
+            InterpolErrorKind::TryReserve => format!("Memory allocation error: {}", self.reason),
+            InterpolErrorKind::DeriveBuilder => format!("Builder error: {}", self.reason),
+            // _ => String::from("Unknown error kind"),
         };
 
         write!(f, "{err_msg}")

--- a/interpol-rs/src/mpi_events/collectives/mpi_ibcast.rs
+++ b/interpol-rs/src/mpi_events/collectives/mpi_ibcast.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Builder, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MpiIbcast {
     current_rank: MpiRank,
-    root_rank: MpiRank,
+    partner_rank: MpiRank,
     nb_bytes: u32,
     comm: MpiComm,
     req: MpiReq,
@@ -29,7 +29,7 @@ impl MpiIbcast {
     /// Creates a new `MpiIbcast` structure from the specified parameters.
     pub fn new(
         current_rank: MpiRank,
-        root_rank: MpiRank,
+        partner_rank: MpiRank,
         nb_bytes: u32,
         comm: MpiComm,
         req: MpiReq,
@@ -38,7 +38,7 @@ impl MpiIbcast {
     ) -> Self {
         MpiIbcast {
             current_rank,
-            root_rank,
+            partner_rank,
             nb_bytes,
             comm,
             req,
@@ -61,7 +61,7 @@ mod tests {
         let ibcast_new = MpiIbcast::new(0, 1, 8, MPI_COMM_WORLD, 7, 1024, 2048);
         let ibcast_builder = MpiIbcastBuilder::default()
             .current_rank(0)
-            .root_rank(1)
+            .partner_rank(1)
             .nb_bytes(8)
             .comm(MPI_COMM_WORLD)
             .req(7)
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn serializes() {
         let ibcast = MpiIbcast::new(0, 0, 8, MPI_COMM_WORLD, 7, 1024, 2048);
-        let json = String::from("{\"current_rank\":0,\"root_rank\":0,\"nb_bytes\":8,\"comm\":0,\"req\":7,\"tsc\":1024,\"duration\":2048}");
+        let json = String::from("{\"current_rank\":0,\"partner_rank\":0,\"nb_bytes\":8,\"comm\":0,\"req\":7,\"tsc\":1024,\"duration\":2048}");
         let serialized = serde_json::to_string(&ibcast).expect("failed to serialize `MpiIbcast`");
 
         assert_eq!(json, serialized);
@@ -86,7 +86,7 @@ mod tests {
     fn deserializes() {
         let ibcast = MpiIbcastBuilder::default()
             .current_rank(1)
-            .root_rank(0)
+            .partner_rank(0)
             .nb_bytes(8)
             .comm(MPI_COMM_WORLD)
             .req(7)

--- a/interpol-rs/src/mpi_events/collectives/mpi_igather.rs
+++ b/interpol-rs/src/mpi_events/collectives/mpi_igather.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Builder, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MpiIgather {
     current_rank: MpiRank,
-    root_rank: MpiRank,
+    partner_rank: MpiRank,
     nb_bytes_send: u32,
     nb_bytes_recv: u32,
     comm: MpiComm,
@@ -31,7 +31,7 @@ impl MpiIgather {
     /// Creates a new `MpiIgather` structure from the specified parameters.
     pub fn new(
         current_rank: MpiRank,
-        root_rank: MpiRank,
+        partner_rank: MpiRank,
         nb_bytes_send: u32,
         nb_bytes_recv: u32,
         comm: MpiComm,
@@ -41,7 +41,7 @@ impl MpiIgather {
     ) -> Self {
         MpiIgather {
             current_rank,
-            root_rank,
+            partner_rank,
             nb_bytes_send,
             nb_bytes_recv,
             comm,
@@ -65,7 +65,7 @@ mod tests {
         let igather_new = MpiIgather::new(0, 1, 8, 0, MPI_COMM_WORLD, 7, 1024, 2048);
         let igather_builder = MpiIgatherBuilder::default()
             .current_rank(0)
-            .root_rank(1)
+            .partner_rank(1)
             .nb_bytes_send(8)
             .nb_bytes_recv(0)
             .comm(MPI_COMM_WORLD)
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn serializes() {
         let igather = MpiIgather::new(0, 0, 8, 64, MPI_COMM_WORLD, 7, 1024, 2048);
-        let json = String::from("{\"current_rank\":0,\"root_rank\":0,\"nb_bytes_send\":8,\"nb_bytes_recv\":64,\"comm\":0,\"req\":7,\"tsc\":1024,\"duration\":2048}");
+        let json = String::from("{\"current_rank\":0,\"partner_rank\":0,\"nb_bytes_send\":8,\"nb_bytes_recv\":64,\"comm\":0,\"req\":7,\"tsc\":1024,\"duration\":2048}");
         let serialized = serde_json::to_string(&igather).expect("failed to serialize `MpiIgather`");
 
         assert_eq!(json, serialized);
@@ -91,7 +91,7 @@ mod tests {
     fn deserializes() {
         let igather = MpiIgatherBuilder::default()
             .current_rank(1)
-            .root_rank(0)
+            .partner_rank(0)
             .nb_bytes_send(64)
             .nb_bytes_recv(0)
             .comm(MPI_COMM_WORLD)

--- a/interpol-rs/src/mpi_events/collectives/mpi_ireduce.rs
+++ b/interpol-rs/src/mpi_events/collectives/mpi_ireduce.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Builder, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MpiIreduce {
     current_rank: MpiRank,
-    root_rank: MpiRank,
+    partner_rank: MpiRank,
     nb_bytes: u32,
     op_type: i8,
     comm: MpiComm,
@@ -31,7 +31,7 @@ impl MpiIreduce {
     /// Creates a new `MpiIreduce` structure from the specified parameters.
     pub fn new(
         current_rank: MpiRank,
-        root_rank: MpiRank,
+        partner_rank: MpiRank,
         nb_bytes: u32,
         op_type: i8,
         comm: MpiComm,
@@ -41,7 +41,7 @@ impl MpiIreduce {
     ) -> Self {
         MpiIreduce {
             current_rank,
-            root_rank,
+            partner_rank,
             nb_bytes,
             op_type,
             comm,
@@ -72,7 +72,7 @@ mod tests {
             MpiIreduce::new(0, 1, 8, MpiOpType::Sum as i8, MPI_COMM_WORLD, 7, 1024, 2048);
         let ireduce_builder = MpiIreduceBuilder::default()
             .current_rank(0)
-            .root_rank(1)
+            .partner_rank(1)
             .nb_bytes(8)
             .op_type(MpiOpType::Sum as i8)
             .comm(MPI_COMM_WORLD)
@@ -97,7 +97,7 @@ mod tests {
             1024,
             2048,
         );
-        let json = String::from("{\"current_rank\":0,\"root_rank\":0,\"nb_bytes\":8,\"op_type\":2,\"comm\":0,\"req\":7,\"tsc\":1024,\"duration\":2048}");
+        let json = String::from("{\"current_rank\":0,\"partner_rank\":0,\"nb_bytes\":8,\"op_type\":2,\"comm\":0,\"req\":7,\"tsc\":1024,\"duration\":2048}");
         let serialized = serde_json::to_string(&ireduce).expect("failed to serialize `MpiIreduce`");
 
         assert_eq!(json, serialized);
@@ -107,7 +107,7 @@ mod tests {
     fn deserializes() {
         let ireduce = MpiIreduceBuilder::default()
             .current_rank(1)
-            .root_rank(0)
+            .partner_rank(0)
             .nb_bytes(8)
             .op_type(MpiOpType::Max as i8)
             .comm(MPI_COMM_WORLD)

--- a/interpol-rs/src/mpi_events/collectives/mpi_iscatter.rs
+++ b/interpol-rs/src/mpi_events/collectives/mpi_iscatter.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Builder, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MpiIscatter {
     current_rank: MpiRank,
-    root_rank: MpiRank,
+    partner_rank: MpiRank,
     nb_bytes_send: u32,
     nb_bytes_recv: u32,
     comm: MpiComm,
@@ -31,7 +31,7 @@ impl MpiIscatter {
     /// Creates a new `MpiIscatter` structure from the specified parameters.
     pub fn new(
         current_rank: MpiRank,
-        root_rank: MpiRank,
+        partner_rank: MpiRank,
         nb_bytes_send: u32,
         nb_bytes_recv: u32,
         comm: MpiComm,
@@ -41,7 +41,7 @@ impl MpiIscatter {
     ) -> Self {
         MpiIscatter {
             current_rank,
-            root_rank,
+            partner_rank,
             nb_bytes_send,
             nb_bytes_recv,
             comm,
@@ -65,7 +65,7 @@ mod tests {
         let iscatter_new = MpiIscatter::new(0, 1, 8, 0, MPI_COMM_WORLD, 7, 1024, 2048);
         let iscatter_builder = MpiIscatterBuilder::default()
             .current_rank(0)
-            .root_rank(1)
+            .partner_rank(1)
             .nb_bytes_send(8)
             .nb_bytes_recv(0)
             .comm(MPI_COMM_WORLD)
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn serializes() {
         let iscatter = MpiIscatter::new(0, 0, 8, 64, MPI_COMM_WORLD, 7, 1024, 2048);
-        let json = String::from("{\"current_rank\":0,\"root_rank\":0,\"nb_bytes_send\":8,\"nb_bytes_recv\":64,\"comm\":0,\"req\":7,\"tsc\":1024,\"duration\":2048}");
+        let json = String::from("{\"current_rank\":0,\"partner_rank\":0,\"nb_bytes_send\":8,\"nb_bytes_recv\":64,\"comm\":0,\"req\":7,\"tsc\":1024,\"duration\":2048}");
         let serialized =
             serde_json::to_string(&iscatter).expect("failed to serialize `MpiIscatter`");
 
@@ -92,7 +92,7 @@ mod tests {
     fn deserializes() {
         let iscatter = MpiIscatterBuilder::default()
             .current_rank(1)
-            .root_rank(0)
+            .partner_rank(0)
             .nb_bytes_send(64)
             .nb_bytes_recv(0)
             .comm(MPI_COMM_WORLD)


### PR DESCRIPTION
## Description
This PR fixes a rustc warning about an unreachable pattern in the error handling. Also changed the `root_rank` field in the NBCs for `partner_rank` to simplify the work of the GUI Interpol Trace Analyzer.

Bumped version of the library to v0.2.2.